### PR TITLE
Changed implementations of Similar Movies/TV Shows & Next Episodes widgets

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 
 * Similar Movies widget will ignore watched titles by default, regardless of global options.
 
+* Updated get_next_episode_for_show to return the next unwatched episode AFTER the most recently watched episode.  This replicates LazyTV behavior
+
 # script.skin.helper.widgets
 Addon for Kodi providing widgets for all kinds of media types
 
@@ -247,7 +249,7 @@ plugin://script.skin.helper.widgets/?action=unaired&mediatype=episodes&reload=$I
 ```
 Provides a listing for episodes for tvshows in the Kodi library that are airing within the next 2 months.
 
-All listitem properties should be the same as any other episode listitem, 
+All listitem properties should be the same as any other episode listitem,
 all properties should be correctly filled with the correct info.
 Just treat the widget as any other episode widget and you should have all the details properly set.
 If not, let me know ;-)
@@ -318,5 +320,3 @@ plugin://myvideoplugin/movies/?latest&reload=$INFO[Window(Home).Property(widgetr
 |Window(Home).Property(widgetreload-tvshows) | will change if tvshows content is added/changed in the library |
 |Window(Home).Property(widgetreload-music) | will change if any music content is added/changed in the library or after playback stop of music (in- or outside of library) |
 |Window(Home).Property(widgetreload2) | will change every 10 minutes (e.g. for pvr widgets or favourites) |
-
-

--- a/README.md
+++ b/README.md
@@ -1,13 +1,3 @@
-## Fork of  marcelveldt's script.skin.helper.widgets
-
-### Changes:
-
-* Similar movies and TV Shows are sorted based on number of matching genres, not rating.  Combined with the genres provided by [DVDNetflixScraper](https://github.com/patrick-klein/DVDNetflixScraper), this provides exceptionally useful recommendations.
-
-* Similar Movies widget will ignore watched titles by default, regardless of global options.
-
-* Updated get_next_episode_for_show to return the next unwatched episode AFTER the most recently watched episode.  This replicates LazyTV behavior
-
 # script.skin.helper.widgets
 Addon for Kodi providing widgets for all kinds of media types
 
@@ -27,7 +17,7 @@ Most important/used methods are listed below:
 ```
 plugin://script.skin.helper.widgets/?action=next&mediatype=episodes&reload=$INFO[Window(Home).Property(widgetreload)]
 ```
-Provides a list of the nextup episodes. This can be the first episode in progress from a tv show or the next unwatched from a in progress show.
+Provides a list of the nextup episodes. Searches for next episode after the last played, otherwise returns the first unwatched episode.
 Note: the reload parameter is needed to auto refresh the widget when the content has changed.
 
 ________________________________________________________________________________________________________
@@ -118,7 +108,7 @@ ________________________________________________________________________________
 ```
 plugin://script.skin.helper.widgets/?action=similar&mediatype=movies&reload=$INFO[Window(Home).Property(widgetreload2)]
 ```
-This will provide a list with movies that are similar to a random watched movie from the library.
+This will provide a list with unwatched movies that are similar to a random watched movie from the library, sorted by number of matching genres then rating.
 TIP: The listitem provided by this list will have a property "similartitle" which contains the movie from which this list is generated. That way you can create a "Because you watched $INFO[Container.ListItem.Property(originaltitle)]" label....
 Note: You can optionally provide the widgetreload2 parameter if you want to refresh the widget every 10 minutes. If you want to refresh the widget on other circumstances just provide any changing info with the reload parameter, such as the window title or some window Property which you change on X interval.
 
@@ -135,7 +125,7 @@ ________________________________________________________________________________
 ```
 plugin://script.skin.helper.widgets/?action=similarshows&reload=$INFO[Window(Home).Property(widgetreload2)]
 ```
-This will provide a list with TV shows that are similar to a random in progress show from the library.
+This will provide a list with TV shows that are similar to a random in progress show from the library, sorted by number of matching genres, then rating.
 TIP: The listitem provided by this list will have a property "similartitle" which contains the movie from which this list is generated. That way you can create a "Because you watched $INFO[Container.ListItem.Property(originaltitle)]" label....
 Note: You can optionally provide the widgetreload2 parameter if you want to refresh the widget every 10 minutes. If you want to refresh the widget on other circumstances just provide any changing info with the reload parameter, such as the window title or some window Property which you change on X interval.
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,11 @@
+## Fork of  marcelveldt's script.skin.helper.widgets
+
+### Changes:
+
+* Similar movies and TV Shows are sorted based on number of matching genres, not rating.  Combined with the genres provided by [DVDNetflixScraper](https://github.com/patrick-klein/DVDNetflixScraper), this provides exceptionally useful recommendations.
+
+* Similar Movies widget will ignore watched titles by default, regardless of global options.
+
 # script.skin.helper.widgets
 Addon for Kodi providing widgets for all kinds of media types
 

--- a/resources/lib/episodes.py
+++ b/resources/lib/episodes.py
@@ -186,7 +186,7 @@ class Episodes(object):
                                 return all_episodes[index+i]
                             i += 1
                 return None # this line should never be executed
-            except:
+            except IndexError:
                 return first_unwatched_episode[0]
         else:
             return None

--- a/resources/lib/movies.py
+++ b/resources/lib/movies.py
@@ -137,7 +137,7 @@ class Movies(object):
                         all_items.append(item)
                         all_titles.append(item["title"])
         # restore hide_watched settings
-        hide_watched = self.options["hide_watched"]
+        self.options["hide_watched"] = hide_watched
         # return the list capped by limit and sorted by number of matching genres then rating
         items_by_rating = sorted(all_items, key=itemgetter("rating"), reverse=True)
         return sorted(items_by_rating, key=itemgetter("num_match"), reverse=True)[:self.options["limit"]]

--- a/resources/lib/movies.py
+++ b/resources/lib/movies.py
@@ -132,8 +132,9 @@ class Movies(object):
                         item["num_match"] = len(set(genres).intersection(item["genre"]))
                         all_items.append(item)
                         all_titles.append(item["title"])
-        # return the list capped by limit and sorted by number of matching genres
-        return sorted(all_items, key=itemgetter("num_match"), reverse=True)[:self.options["limit"]]
+        # return the list capped by limit and sorted by number of matching genres then rating
+        items_by_rating = sorted(all_items, key=itemgetter("rating"), reverse=True)
+        return sorted(items_by_rating, key=itemgetter("num_match"), reverse=True)[:self.options["limit"]]
 
 
     def forgenre(self):
@@ -242,6 +243,7 @@ class Movies(object):
 
     def get_genre_movies(self, genre, hide_watched=False, limit=100):
         '''helper method to get all movies in a specific genre'''
+        limit=1000  # similar movies is too inconsisent without a high limit
         filters = [{"operator": "is", "field": "genre", "value": genre}]
         if self.options.get("tag"):
             filters.append({"operator": "contains", "field": "tag", "value": self.options["tag"]})

--- a/resources/lib/movies.py
+++ b/resources/lib/movies.py
@@ -104,13 +104,13 @@ class Movies(object):
         return self.metadatautils.kodidb.movies(sort=kodi_constants.SORT_TITLE, filters=filters,
                                            limits=(0, self.options["limit"]))
 
+
     def similar(self):
         ''' get similar movies for given imdbid or just from random watched title if no imdbid'''
         imdb_id = self.options.get("imdbid", "")
         all_items = []
         all_titles = list()
         # lookup movie by imdbid or just pick a random watched movie
-
         ref_movie = None
         if imdb_id:
             # get movie by imdbid
@@ -129,10 +129,12 @@ class Movies(object):
                     # prevent duplicates so skip reference movie and titles already in the list
                     if not item["title"] in all_titles and not item["title"] == similar_title:
                         item["extraproperties"] = {"similartitle": similar_title, "originalpath": item["file"]}
+                        item["num_match"] = len(set(genres).intersection(item["genre"]))
                         all_items.append(item)
                         all_titles.append(item["title"])
-        # return the list capped by limit and sorted by rating
-        return sorted(all_items, key=itemgetter("rating"), reverse=True)[:self.options["limit"]]
+        # return the list capped by limit and sorted by number of matching genres
+        return sorted(all_items, key=itemgetter("num_match"), reverse=True)[:self.options["limit"]]
+
 
     def forgenre(self):
         ''' get top rated movies for given genre'''

--- a/resources/lib/movies.py
+++ b/resources/lib/movies.py
@@ -112,12 +112,16 @@ class Movies(object):
         all_titles = list()
         # lookup movie by imdbid or just pick a random watched movie
         ref_movie = None
+        hide_watched = self.options["hide_watched"]
         if imdb_id:
             # get movie by imdbid
             ref_movie = self.metadatautils.kodidb.movie_by_imdbid(imdb_id)
         if not ref_movie:
             # just get a random watched movie
             ref_movie = self.get_random_watched_movie()
+            # when getting a random movie, it's for a homescreen widget, and
+            # and that means it should hide watched movies
+            self.options["hide_watched"] = True
         if ref_movie:
             # get all movies for the genres in the movie
             genres = ref_movie["genre"]
@@ -132,6 +136,8 @@ class Movies(object):
                         item["num_match"] = len(set(genres).intersection(item["genre"]))
                         all_items.append(item)
                         all_titles.append(item["title"])
+        # restore hide_watched settings
+        hide_watched = self.options["hide_watched"]
         # return the list capped by limit and sorted by number of matching genres then rating
         items_by_rating = sorted(all_items, key=itemgetter("rating"), reverse=True)
         return sorted(items_by_rating, key=itemgetter("num_match"), reverse=True)[:self.options["limit"]]

--- a/resources/lib/tvshows.py
+++ b/resources/lib/tvshows.py
@@ -138,8 +138,6 @@ class Tvshows(object):
                         all_items.append(item)
                         all_titles.append(item["title"])
         # return the list capped by limit and sorted by rating
-        #tvshows = sorted(all_items, key=itemgetter("rating"), reverse=True)[:self.options["limit"]]
-        #return process_method_on_list(self.process_tvshow, tvshows)
         items_by_rating = sorted(all_items, key=itemgetter("rating"), reverse=True)
         tvshows = sorted(items_by_rating, key=itemgetter("num_match"), reverse=True)[:self.options["limit"]]
         return process_method_on_list(self.process_tvshow, tvshows)
@@ -257,6 +255,7 @@ class Tvshows(object):
 
     def get_genre_tvshows(self, genre, hide_watched=False, limit=100):
         '''helper method to get all tvshows in a specific genre'''
+        limit=1000 # similar tvshows is too inconsistent without a high limit
         filters = [{"operator": "is", "field": "genre", "value": genre}]
         if hide_watched:
             filters.append(kodi_constants.FILTER_UNWATCHED)

--- a/resources/lib/tvshows.py
+++ b/resources/lib/tvshows.py
@@ -134,11 +134,16 @@ class Tvshows(object):
                     # prevent duplicates so skip reference tvshow and titles already in the list
                     if not item["title"] in all_titles and not item["title"] == similar_title:
                         item["extraproperties"] = {"similartitle": similar_title, "originalpath": item["file"]}
+                        item["num_match"] = len(set(genres).intersection(item["genre"]))
                         all_items.append(item)
                         all_titles.append(item["title"])
         # return the list capped by limit and sorted by rating
-        tvshows = sorted(all_items, key=itemgetter("rating"), reverse=True)[:self.options["limit"]]
+        #tvshows = sorted(all_items, key=itemgetter("rating"), reverse=True)[:self.options["limit"]]
+        #return process_method_on_list(self.process_tvshow, tvshows)
+        items_by_rating = sorted(all_items, key=itemgetter("rating"), reverse=True)
+        tvshows = sorted(items_by_rating, key=itemgetter("num_match"), reverse=True)[:self.options["limit"]]
         return process_method_on_list(self.process_tvshow, tvshows)
+
 
     def forgenre(self):
         ''' get top rated tvshows for given genre'''


### PR DESCRIPTION
-Similar Movies and TV Shows are sorted based on number of matching genres, then rating

-Similar Movies widget will ignore watched titles (Note: only applies to widget)

-Next Episodes return the next unwatched episode AFTER the most recently watched episode