### PR TITLE
Force similar movies widget to use recently watched movie

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ ________________________________________________________________________________
 ```
 plugin://script.skin.helper.widgets/?action=similar&mediatype=movies&reload=$INFO[Window(Home).Property(widgetreload2)]
 ```
-This will provide a list with unwatched movies that are similar to a random watched movie from the library, sorted by number of matching genres then rating.
+This will provide a list with unwatched movies that are similar to a random recently watched movie from the library, sorted by number of matching genres then rating.
 TIP: The listitem provided by this list will have a property "similartitle" which contains the movie from which this list is generated. That way you can create a "Because you watched $INFO[Container.ListItem.Property(originaltitle)]" label....
 Note: You can optionally provide the widgetreload2 parameter if you want to refresh the widget every 10 minutes. If you want to refresh the widget on other circumstances just provide any changing info with the reload parameter, such as the window title or some window Property which you change on X interval.
 

--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -303,3 +303,7 @@ msgstr ""
 msgctxt "#32071"
 msgid "Enable aggresive refresh of widgets"
 msgstr ""
+
+msgctxt "#32072"
+msgid "Number of recently watched movies for Similar Movies"
+msgstr ""

--- a/resources/lib/main.py
+++ b/resources/lib/main.py
@@ -99,6 +99,7 @@ class Main(object):
         options["hide_watched"] = self.addon.getSetting("hide_watched") == "true"
         if self.addon.getSetting("hide_watched_recent") == "true" and "recent" in options.get("action", ""):
             options["hide_watched"] = True
+        options["num_recent_similar"] = int(self.addon.getSetting("num_recent_similar"))
         options["next_inprogress_only"] = self.addon.getSetting("nextup_inprogressonly") == "true"
         options["episodes_enable_specials"] = self.addon.getSetting("episodes_enable_specials") == "true"
         options["group_episodes"] = self.addon.getSetting("episodes_grouping") == "true"

--- a/resources/lib/movies.py
+++ b/resources/lib/movies.py
@@ -251,8 +251,9 @@ class Movies(object):
 
     def get_recently_watched_movie(self):
         '''gets a random recently watched movie from kodi_constants.'''
+        num_recent_similar = self.options["num_recent_similar"]
         movies = self.metadatautils.kodidb.movies(sort=kodi_constants.SORT_LASTPLAYED,
-                                             filters=[kodi_constants.FILTER_WATCHED], limits=(0, 20))
+                                             filters=[kodi_constants.FILTER_WATCHED], limits=(0, num_recent_similar))
         if movies:
             return movies[randint(0,len(movies)-1)]
         else:

--- a/resources/lib/movies.py
+++ b/resources/lib/movies.py
@@ -10,6 +10,7 @@
 from utils import create_main_entry, KODI_VERSION
 from operator import itemgetter
 from metadatautils import kodi_constants
+from random import randint
 import xbmc
 
 
@@ -118,7 +119,7 @@ class Movies(object):
             ref_movie = self.metadatautils.kodidb.movie_by_imdbid(imdb_id)
         if not ref_movie:
             # just get a random watched movie
-            ref_movie = self.get_random_watched_movie()
+            ref_movie = self.get_random_recently_watched_movie()
             # when getting a random movie, it's for a homescreen widget, and
             # and that means it should hide watched movies
             self.options["hide_watched"] = True
@@ -245,6 +246,15 @@ class Movies(object):
                                              filters=[kodi_constants.FILTER_WATCHED], limits=(0, 1))
         if movies:
             return movies[0]
+        else:
+            return None
+
+    def get_random_recently_watched_movie(self):
+        '''gets a random recently watched movie from kodi_constants.'''
+        movies = self.metadatautils.kodidb.movies(sort=kodi_constants.SORT_LASTPLAYED,
+                                             filters=[kodi_constants.FILTER_WATCHED], limits=(0, 20))
+        if movies:
+            return movies[randint(0,len(movies)-1)]
         else:
             return None
 

--- a/resources/lib/movies.py
+++ b/resources/lib/movies.py
@@ -119,7 +119,7 @@ class Movies(object):
             ref_movie = self.metadatautils.kodidb.movie_by_imdbid(imdb_id)
         if not ref_movie:
             # just get a random watched movie
-            ref_movie = self.get_random_recently_watched_movie()
+            ref_movie = self.get_recently_watched_movie()
             # when getting a random movie, it's for a homescreen widget, and
             # and that means it should hide watched movies
             self.options["hide_watched"] = True
@@ -249,7 +249,7 @@ class Movies(object):
         else:
             return None
 
-    def get_random_recently_watched_movie(self):
+    def get_recently_watched_movie(self):
         '''gets a random recently watched movie from kodi_constants.'''
         movies = self.metadatautils.kodidb.movies(sort=kodi_constants.SORT_LASTPLAYED,
                                              filters=[kodi_constants.FILTER_WATCHED], limits=(0, 20))

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -6,6 +6,7 @@
         <setting id="hide_watched_recent" type="bool" label="32067" default="true"/>
         <setting id="default_limit" type="number" label="32053" default="25"/>
         <setting id="aggresive_refresh" type="bool" label="32071" default="false"/>
+        <setting id="num_recent_similar" type="number" label="32072" default="8"/>
     </category>
     <!-- episodes -->
     <category label="$LOCALIZE[20360]">


### PR DESCRIPTION
Similar Movies widget will randomly pick from last 8 movies watched (configurable in settings), instead of any watched movie.