### PR TITLE
Fix for local channel logos not showing in Landscape layouts.

### DIFF
--- a/resources/lib/pvr.py
+++ b/resources/lib/pvr.py
@@ -132,7 +132,7 @@ class Pvr(object):
         '''transform the json received from kodi into something we can use'''
         item = {}
         channelname = channeldata["label"]
-        channellogo = self.metadatautils.get_clean_image(channeldata['thumbnail'])
+        channellogo = channeldata['thumbnail']
         if channeldata.get('broadcastnow'):
             # channel with epg data
             item = channeldata['broadcastnow']
@@ -147,7 +147,6 @@ class Pvr(object):
                         item["title"], channelname, item["genre"]))
         else:
             # channel without epg
-            item = channeldata
             item["title"] = xbmc.getLocalizedString(161)
         item["file"] = u"plugin://script.skin.helper.service?action=playchannel&channelid=%s"\
             % (channeldata["channelid"])


### PR DESCRIPTION
Setting the art thumb to a cleaned value like this
`special://userdata/addon_data/pvr.nextpvr/nextpvr-ch7285.png`
doesn't work for the Landscape, Landscape Large Netflix, or Landscape Small layouts

Setting the art thumb to the original thumbnail value like this works
`image://special%3a%2f%2fuserdata%2faddon_data%2fpvr.nextpvr%2fnextpvr-ch7285.png/`

I tested that this original thumbnail url also works for all the other layouts.

Also removed the extra unnecessary properties (such as thumbnail) from the item when broadcastnow isn't present, so that they're consistent with when broadcastnow is present. Before I changed the thumb url this was causing thumbnails to appear at first, but then disappear once broadcastnow information was loaded.