### PR TITLE
Similar widgets improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,9 @@ ________________________________________________________________________________
 ```
 plugin://script.skin.helper.widgets/?action=recommended&mediatype=movies&reload=$INFO[Window(Home).Property(widgetreload-movies)]
 ```
-Provides a list of the in progress movies AND recommended movies based on rating.
-Note: the reload parameter is needed to auto refresh the widget when the content has changed.
+Provides a list of the in-progress movies AND movies sorted by rating.
+An alternate behavior for this widget is available in settings, which finds movies similar to all recently watched movies.  The experimental version is slower, and not recommended for low-power systems.
+Note: the reload parameter is needed to auto refresh the widget when the content has changed (non-experimental version only).
 
 ________________________________________________________________________________________________________
 
@@ -108,11 +109,11 @@ ________________________________________________________________________________
 ```
 plugin://script.skin.helper.widgets/?action=similar&mediatype=movies&reload=$INFO[Window(Home).Property(widgetreload2)]
 ```
-This will provide a list with unwatched movies that are similar to a random recently watched movie from the library (similarity is based on genres, writers, directors, movie set & rating).
+This will provide a list with unwatched movies that are similar to a random recently watched movie from the library (similarity is based on several factors, including matching genres, writers, directors, movie set & rating).
 TIP: The listitem provided by this list will have a property "similartitle" which contains the movie from which this list is generated. That way you can create a "Because you watched $INFO[Container.ListItem.Property(originaltitle)]" label....
 Note: You can optionally provide the widgetreload2 parameter if you want to refresh the widget every 10 minutes. If you want to refresh the widget on other circumstances just provide any changing info with the reload parameter, such as the window title or some window Property which you change on X interval.
 
-The above command will create a similar movies listing based on a random watched movie in the library.
+The above command will create a similar movies listing based on a random recently watched movie in the library.
 If you want to specify the movie to base the request on yourself you can optionally specify the imdb id to the script:
 
 ```
@@ -190,7 +191,7 @@ ________________________________________________________________________________
 ```
 plugin://script.skin.helper.widgets/?action=inprogressandrecommended&mediatype=media&reload=$INFO[Window(Home).Property(widgetreload)]
 ```
-This combines in progress media and recommended media, usefull to prevent an empty widget when no items are in progress.
+This combines in progress media and recommended media, useful to prevent an empty widget when no items are in progress.
 Note: the reload parameter is needed to auto refresh the widget when the content has changed.
 
 ________________________________________________________________________________________________________

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ ________________________________________________________________________________
 ```
 plugin://script.skin.helper.widgets/?action=similar&mediatype=movies&reload=$INFO[Window(Home).Property(widgetreload2)]
 ```
-This will provide a list with unwatched movies that are similar to a random watched movie from the library, sorted by number of matching genres then rating.
+This will provide a list with unwatched movies that are similar to a random recently watched movie from the library, sorted by number of matching genres then rating.
 TIP: The listitem provided by this list will have a property "similartitle" which contains the movie from which this list is generated. That way you can create a "Because you watched $INFO[Container.ListItem.Property(originaltitle)]" label....
 Note: You can optionally provide the widgetreload2 parameter if you want to refresh the widget every 10 minutes. If you want to refresh the widget on other circumstances just provide any changing info with the reload parameter, such as the window title or some window Property which you change on X interval.
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Most important/used methods are listed below:
 
 
 
-#####Next Episodes
+##### Next Episodes
 ```
 plugin://script.skin.helper.widgets/?action=next&mediatype=episodes&reload=$INFO[Window(Home).Property(widgetreload)]
 ```
@@ -22,7 +22,7 @@ Note: the reload parameter is needed to auto refresh the widget when the content
 
 ________________________________________________________________________________________________________
 
-#####Recommended Movies
+##### Recommended Movies
 ```
 plugin://script.skin.helper.widgets/?action=recommended&mediatype=movies&reload=$INFO[Window(Home).Property(widgetreload-movies)]
 ```
@@ -31,7 +31,7 @@ Note: the reload parameter is needed to auto refresh the widget when the content
 
 ________________________________________________________________________________________________________
 
-#####Recommended Media
+##### Recommended Media
 ```
 plugin://script.skin.helper.widgets/?action=recommended&mediatype=media&reload=$INFO[Window(Home).Property(widgetreload2)]
 ```
@@ -40,7 +40,7 @@ Note: You can optionally provide the reload= parameter if you want to refresh th
 
 ________________________________________________________________________________________________________
 
-#####Recent albums
+##### Recent albums
 ```
 plugin://script.skin.helper.widgets/?action=recent&mediatype=albums&reload=$INFO[Window(Home).Property(widgetreload-music)]
 ```
@@ -50,7 +50,7 @@ Note: You can optionally provide the reload= parameter if you want to refresh th
 Optional argument: browse=true --> will open/browse the album instead of playing it
 ________________________________________________________________________________________________________
 
-#####Recently played albums
+##### Recently played albums
 ```
 plugin://script.skin.helper.widgets/?action=recentplayed&mediatype=albums&reload=$INFO[Window(Home).Property(widgetreload-music)]
 ```
@@ -60,7 +60,7 @@ Note: You can optionally provide the reload= parameter if you want to refresh th
 Optional argument: browse=true --> will open/browse the album instead of playing it
 ________________________________________________________________________________________________________
 
-#####Recommended albums
+##### Recommended albums
 ```
 plugin://script.skin.helper.widgets/?action=recommended&mediatype=albums&reload=$INFO[Window(Home).Property(widgetreload-music)]
 ```
@@ -70,7 +70,7 @@ Note: You can optionally provide the reload= parameter if you want to refresh th
 Optional argument: browse=true --> will open/browse the album instead of playing it
 ________________________________________________________________________________________________________
 
-#####Recent songs
+##### Recent songs
 ```
 plugin://script.skin.helper.widgets/?action=recent&mediatype=songs&reload=$INFO[Window(Home).Property(widgetreload-music)]
 ```
@@ -78,7 +78,7 @@ Provides a list of recently added songs, including the artwork provided by this 
 Note: You can optionally provide the reload= parameter if you want to refresh the widget on library changes.
 ________________________________________________________________________________________________________
 
-#####Recently played songs
+##### Recently played songs
 ```
 plugin://script.skin.helper.widgets/?action=recentplayed&mediatype=songs&reload=$INFO[Window(Home).Property(widgetreload-music)]
 ```
@@ -86,7 +86,7 @@ Provides a list of recently played songs, including the artwork provided by this
 Note: You can optionally provide the reload= parameter if you want to refresh the widget on library changes.
 ________________________________________________________________________________________________________
 
-#####Recommended songs
+##### Recommended songs
 ```
 plugin://script.skin.helper.widgets/?action=recommended&mediatype=songs&reload=$INFO[Window(Home).Property(widgetreload-music)]
 ```
@@ -94,7 +94,7 @@ Provides a list of recommended songs, including the artwork provided by this scr
 Note: You can optionally provide the reload= parameter if you want to refresh the widget on library changes.
 ________________________________________________________________________________________________________
 
-#####Recent Media
+##### Recent Media
 ```
 plugin://script.skin.helper.widgets/?action=recent&mediatype=media&reload=$INFO[Window(Home).Property(widgetreload2)]
 ```
@@ -104,11 +104,11 @@ Note: You can optionally provide the reload= parameter if you want to refresh th
 
 ________________________________________________________________________________________________________
 
-#####Similar Movies (because you watched...)
+##### Similar Movies (because you watched...)
 ```
 plugin://script.skin.helper.widgets/?action=similar&mediatype=movies&reload=$INFO[Window(Home).Property(widgetreload2)]
 ```
-This will provide a list with unwatched movies that are similar to a random watched movie from the library, sorted by number of matching genres then rating.
+This will provide a list with unwatched movies that are similar to a random watched movie from the library (similarity is based on genres, writers, directors, movie set & rating).
 TIP: The listitem provided by this list will have a property "similartitle" which contains the movie from which this list is generated. That way you can create a "Because you watched $INFO[Container.ListItem.Property(originaltitle)]" label....
 Note: You can optionally provide the widgetreload2 parameter if you want to refresh the widget every 10 minutes. If you want to refresh the widget on other circumstances just provide any changing info with the reload parameter, such as the window title or some window Property which you change on X interval.
 
@@ -121,7 +121,7 @@ plugin://script.skin.helper.widgets/?action=similar&mediatype=movies&imdbid=[IMD
 
 ________________________________________________________________________________________________________
 
-#####Similar Tv Shows (because you watched...)
+##### Similar Tv Shows (because you watched...)
 ```
 plugin://script.skin.helper.widgets/?action=similarshows&reload=$INFO[Window(Home).Property(widgetreload2)]
 ```
@@ -138,7 +138,7 @@ plugin://script.skin.helper.widgets/?action=similarshows&imdbid=[IMDBID]
 
 ________________________________________________________________________________________________________
 
-#####Similar Media (because you watched...)
+##### Similar Media (because you watched...)
 ```
 plugin://script.skin.helper.widgets/?action=similar&mediatype=media&reload=$INFO[Window(Home).Property(widgetreload2)]
 ```
@@ -155,7 +155,7 @@ plugin://script.skin.helper.widgets/?action=similarshows&imdbid=[IMDBID]
 
 ________________________________________________________________________________________________________
 
-#####Top rated Movies in genre
+##### Top rated Movies in genre
 ```
 plugin://script.skin.helper.widgets/?action=forgenre&mediatype=movies&reload=$INFO[Window(Home).Property(widgetreload2)]
 ```
@@ -165,7 +165,7 @@ Note: You can optionally provide the widgetreload2 parameter if you want to refr
 
 ________________________________________________________________________________________________________
 
-#####Top rated tvshows in genre
+##### Top rated tvshows in genre
 ```
 plugin://script.skin.helper.widgets/?action=forgenre&mediatype=tvshows&reload=$INFO[Window(Home).Property(widgetreload2)]
 ```
@@ -176,7 +176,7 @@ Note: You can optionally provide the widgetreload2 parameter if you want to refr
 ________________________________________________________________________________________________________
 
 
-#####In progress Media
+##### In progress Media
 ```
 plugin://script.skin.helper.widgets/?action=inprogress&mediatype=media&reload=$INFO[Window(Home).Property(widgetreload)]
 ```
@@ -186,7 +186,7 @@ Note: the reload parameter is needed to auto refresh the widget when the content
 
 ________________________________________________________________________________________________________
 
-#####In progress and Recommended Media
+##### In progress and Recommended Media
 ```
 plugin://script.skin.helper.widgets/?action=inprogressandrecommended&mediatype=media&reload=$INFO[Window(Home).Property(widgetreload)]
 ```
@@ -195,7 +195,7 @@ Note: the reload parameter is needed to auto refresh the widget when the content
 
 ________________________________________________________________________________________________________
 
-#####Favourite Media
+##### Favourite Media
 ```
 plugin://script.skin.helper.widgets/?action=favourite&mediatype=media&reload=$INFO[Window(Home).Property(widgetreload2)]
 ```
@@ -204,7 +204,7 @@ Note: By providing the reload-parameter set to the widgetreload2 property, the w
 
 ________________________________________________________________________________________________________
 
-#####PVR TV Channels widget
+##### PVR TV Channels widget
 ```
 plugin://script.skin.helper.widgets/?action=channels&mediatype=pvr&reload=$INFO[Window(Home).Property(widgetreload2)]
 ```
@@ -213,7 +213,7 @@ Note: By providing the reload-parameter set to the widgetreload2 property, the w
 
 ________________________________________________________________________________________________________
 
-#####PVR Latest Recordings widget
+##### PVR Latest Recordings widget
 ```
 plugin://script.skin.helper.widgets/?action=recordings&mediatype=pvr&reload=$INFO[Window(Home).Property(widgetreload2)]
 ```
@@ -223,7 +223,7 @@ Note: By providing the reload-parameter set to the widgetreload2 property, the w
 
 ________________________________________________________________________________________________________
 
-#####Favourites
+##### Favourites
 ```
 plugin://script.skin.helper.widgets/?mediatype=favourites&reload=$INFO[Window(Home).Property(widgetreload2)]
 ```
@@ -272,7 +272,7 @@ For the listitem properties, see the "unaired episodes" plugin path.
 ________________________________________
 
 
-#####Browse Genres
+##### Browse Genres
 ```
 plugin://script.skin.helper.widgets/?action=browsegenres&mediatype=movies&limit=1000
 plugin://script.skin.helper.widgets/?action=browsegenres&mediatype=tvshows&limit=1000

--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -303,3 +303,7 @@ msgstr ""
 msgctxt "#32071"
 msgid "Enable aggresive refresh of widgets"
 msgstr ""
+
+msgctxt "#32073"
+msgid "Hide watched items in similar movies widget"
+msgstr ""

--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -303,3 +303,7 @@ msgstr ""
 msgctxt "#32071"
 msgid "Enable aggresive refresh of widgets"
 msgstr ""
+
+msgctxt "#32072"
+msgid "Number of recently watched movies for Similar Movies"
+msgstr ""

--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -311,3 +311,7 @@ msgstr ""
 msgctxt "#32073"
 msgid "Hide watched items in similar movies widget"
 msgstr ""
+
+msgctxt "#32074"
+msgid "Enable experimental recommended movies (Very slow)"
+msgstr ""

--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -305,7 +305,7 @@ msgid "Enable aggresive refresh of widgets"
 msgstr ""
 
 msgctxt "#32072"
-msgid "Number of recently watched movies for Similar Movies"
+msgid "Number of recently watched movies for similar movies"
 msgstr ""
 
 msgctxt "#32073"

--- a/resources/lib/main.py
+++ b/resources/lib/main.py
@@ -99,6 +99,7 @@ class Main(object):
         options["hide_watched"] = self.addon.getSetting("hide_watched") == "true"
         if self.addon.getSetting("hide_watched_recent") == "true" and "recent" in options.get("action", ""):
             options["hide_watched"] = True
+        options["hide_watched_similar"] = self.addon.getSetting("hide_watched_similar") == "true"
         options["next_inprogress_only"] = self.addon.getSetting("nextup_inprogressonly") == "true"
         options["episodes_enable_specials"] = self.addon.getSetting("episodes_enable_specials") == "true"
         options["group_episodes"] = self.addon.getSetting("episodes_grouping") == "true"

--- a/resources/lib/main.py
+++ b/resources/lib/main.py
@@ -56,6 +56,21 @@ class Main(object):
 
         options = dict(urlparse.parse_qsl(sys.argv[2].replace('?', '').lower().decode("utf-8")))
 
+        # set the widget settings as options
+        options["hide_watched"] = self.addon.getSetting("hide_watched") == "true"
+        if self.addon.getSetting("hide_watched_recent") == "true" and "recent" in options.get("action", ""):
+            options["hide_watched"] = True
+        options["num_recent_similar"] = int(self.addon.getSetting("num_recent_similar"))
+        options["exp_rec_movies"] = self.addon.getSetting("exp_rec_movies") == "true"
+        options["hide_watched_similar"] = self.addon.getSetting("hide_watched_similar") == "true"
+        options["next_inprogress_only"] = self.addon.getSetting("nextup_inprogressonly") == "true"
+        options["episodes_enable_specials"] = self.addon.getSetting("episodes_enable_specials") == "true"
+        options["group_episodes"] = self.addon.getSetting("episodes_grouping") == "true"
+        if "limit" in options:
+            options["limit"] = int(options["limit"])
+        else:
+            options["limit"] = int(self.addon.getSetting("default_limit"))
+
         if not "mediatype" in options and "action" in options:
             # get the mediatype and action from the path (for backwards compatability with old style paths)
             for item in [
@@ -68,7 +83,7 @@ class Main(object):
                 ("songs", "songs"),
                 ("artists", "artists"),
                 ("media", "media"),
-                ("favourites", "favourites"), 
+                ("favourites", "favourites"),
                     ("favorites", "favourites")]:
                 if item[0] in options["action"]:
                     options["mediatype"] = item[1]
@@ -96,20 +111,9 @@ class Main(object):
                 options["random"] = True
             if options["action"] == "similar":
                 options["skipcache"] = "true"
+            elif options["action"] == "recommended" and options["exp_rec_movies"]:
+                options["skipcache"] = "true"
 
-        # set the widget settings as options
-        options["hide_watched"] = self.addon.getSetting("hide_watched") == "true"
-        if self.addon.getSetting("hide_watched_recent") == "true" and "recent" in options.get("action", ""):
-            options["hide_watched"] = True
-        options["num_recent_similar"] = int(self.addon.getSetting("num_recent_similar"))
-        options["hide_watched_similar"] = self.addon.getSetting("hide_watched_similar") == "true"
-        options["next_inprogress_only"] = self.addon.getSetting("nextup_inprogressonly") == "true"
-        options["episodes_enable_specials"] = self.addon.getSetting("episodes_enable_specials") == "true"
-        options["group_episodes"] = self.addon.getSetting("episodes_grouping") == "true"
-        if "limit" in options:
-            options["limit"] = int(options["limit"])
-        else:
-            options["limit"] = int(self.addon.getSetting("default_limit"))
         return options
 
     def show_widget_listing(self):
@@ -124,7 +128,7 @@ class Main(object):
 
         # try to get from cache first...
         all_items = []
-        cache_str = "SkinHelper.Widgets.%s.%s.%s.%s.%s" % (media_type, 
+        cache_str = "SkinHelper.Widgets.%s.%s.%s.%s.%s" % (media_type,
                     action, self.options["limit"], self.options.get("path"), self.options.get("tag"))
         if not self.win.getProperty("widgetreload2"):
             # at startup we simply accept whatever is in the cache

--- a/resources/lib/main.py
+++ b/resources/lib/main.py
@@ -94,6 +94,8 @@ class Main(object):
             elif options["action"] == "browsegenres" and options["mediatype"] == "randomtvshows":
                 options["mediatype"] = "tvshows"
                 options["random"] = True
+            if options["action"] == "similar":
+                options["skipcache"] = "true"
 
         # set the widget settings as options
         options["hide_watched"] = self.addon.getSetting("hide_watched") == "true"

--- a/resources/lib/main.py
+++ b/resources/lib/main.py
@@ -99,6 +99,7 @@ class Main(object):
         options["hide_watched"] = self.addon.getSetting("hide_watched") == "true"
         if self.addon.getSetting("hide_watched_recent") == "true" and "recent" in options.get("action", ""):
             options["hide_watched"] = True
+        options["num_recent_similar"] = int(self.addon.getSetting("num_recent_similar"))
         options["next_inprogress_only"] = self.addon.getSetting("nextup_inprogressonly") == "true"
         options["episodes_enable_specials"] = self.addon.getSetting("episodes_enable_specials") == "true"
         options["group_episodes"] = self.addon.getSetting("episodes_grouping") == "true"

--- a/resources/lib/movies.py
+++ b/resources/lib/movies.py
@@ -251,8 +251,9 @@ class Movies(object):
 
     def get_recently_watched_movie(self):
         '''gets a random recently watched movie from kodi_constants.'''
+        num_recent_similar = self.options["num_recent_similar"]
         movies = self.metadatautils.kodidb.movies(sort=kodi_constants.SORT_LASTPLAYED,
-                                             filters=[kodi_constants.FILTER_WATCHED], limits=(0, 20))
+                                             filters=[kodi_constants.FILTER_WATCHED], limits=(0, num_recent_similar))
         if movies:
             return movies[randint(0,len(movies)-1)]
         else:

--- a/resources/lib/movies.py
+++ b/resources/lib/movies.py
@@ -10,6 +10,7 @@
 from utils import create_main_entry, KODI_VERSION
 from operator import itemgetter
 from metadatautils import kodi_constants
+from random import randint
 import xbmc
 
 
@@ -118,7 +119,7 @@ class Movies(object):
             ref_movie = self.metadatautils.kodidb.movie_by_imdbid(imdb_id)
         if not ref_movie:
             # just get a random watched movie
-            ref_movie = self.get_random_watched_movie()
+            ref_movie = self.get_random_recently_watched_movie()
             # when getting a random movie, it's for a homescreen widget, and
             # and that means it should hide watched movies
             self.options["hide_watched"] = True
@@ -245,6 +246,15 @@ class Movies(object):
                                              filters=[kodi_constants.FILTER_WATCHED], limits=(0, 1))
         if movies:
             return movies[0]
+        else:
+            return None
+
+    def get_random_recently_watched_movie(self):
+        '''gets a random recently watched movie from kodi_constants.'''
+        movies = self.metadatautils.kodidb.movies(sort=kodi_constants.SORT_LASTPLAYED,
+                                             filters=[kodi_constants.FILTER_WATCHED], limits=(0, 20))
+        if movies:
+            return movies[randint(0,len(movies)-1)]
         else:
             return None
 

--- a/resources/lib/movies.py
+++ b/resources/lib/movies.py
@@ -120,27 +120,51 @@ class Movies(object):
             # just get a random watched movie
             ref_movie = self.get_random_watched_movie()
             # when getting a random movie, it's for a homescreen widget, and
-            # and that means it should hide watched movies
-            self.options["hide_watched"] = True
+            # and that means it should check setting to hide watched
+            if self.options["hide_watched_similar"]:
+	            self.options["hide_watched"] = True
         if ref_movie:
             # get all movies for the genres in the movie
-            genres = ref_movie["genre"]
-            similar_title = ref_movie["title"]
-            for genre in genres:
+            ref_title = ref_movie["title"]
+            ref_genres = ref_movie["genre"]
+            ref_writers = ref_movie["writer"]
+            ref_directors = ref_movie["director"]
+            ref_rating = ref_movie["rating"]
+            ref_setid = ref_movie["setid"]
+            set_genres = set(ref_genres)
+            set_writers = set(ref_writers)
+            set_directors = set(ref_directors)
+            #writer_director_norm = 0.33*float(max(len(ref_writers)+len(ref_directors),1))
+            num_genres = len(ref_genres)
+            num_writers = len(ref_writers)
+            num_directors = len(ref_directors)
+            genre_weight = 5
+            writer_weight = 2
+            director_weight = 2
+            rating_weight = 1
+            set_exp = 1
+            total_weights = float(genre_weight+writer_weight+director_weight+rating_weight)
+            for genre in ref_genres:
                 self.options["genre"] = genre
                 genre_movies = self.forgenre()
                 for item in genre_movies:
                     # prevent duplicates so skip reference movie and titles already in the list
-                    if not item["title"] in all_titles and not item["title"] == similar_title:
-                        item["extraproperties"] = {"similartitle": similar_title, "originalpath": item["file"]}
-                        item["num_match"] = len(set(genres).intersection(item["genre"]))
+                    if not item["title"] in all_titles and not item["title"] == ref_title:
+                        item["extraproperties"] = {"similartitle": ref_title, "originalpath": item["file"]}
+                        genre_score = float(len(set_genres.intersection(item["genre"])))/num_genres
+                    	writer_score = float(len(set_writers.intersection(item["writer"])))/num_writers if num_writers>0 else 0
+                    	director_score = float(len(set_directors.intersection(item["director"])))/num_directors if num_directors>0 else 0
+                    	rating_score = 1-abs(ref_rating-item["rating"])/10 if (ref_rating and item["rating"]) else 0
+                    	similarscore = (genre_score*genre_weight+writer_score*writer_weight+director_score*director_weight+rating_score)/total_weights
+                    	if (ref_setid and ref_setid==item["setid"]):
+                    		similarscore = similarscore**(1/(1+set_exp))
+                    	item["similarscore"] = similarscore
                         all_items.append(item)
                         all_titles.append(item["title"])
         # restore hide_watched settings
         self.options["hide_watched"] = hide_watched
         # return the list capped by limit and sorted by number of matching genres then rating
-        items_by_rating = sorted(all_items, key=itemgetter("rating"), reverse=True)
-        return sorted(items_by_rating, key=itemgetter("num_match"), reverse=True)[:self.options["limit"]]
+        return sorted(all_items, key=itemgetter("similarscore"), reverse=True)[:self.options["limit"]]
 
 
     def forgenre(self):

--- a/resources/lib/movies.py
+++ b/resources/lib/movies.py
@@ -119,7 +119,7 @@ class Movies(object):
             ref_movie = self.metadatautils.kodidb.movie_by_imdbid(imdb_id)
         if not ref_movie:
             # just get a random watched movie
-            ref_movie = self.get_random_recently_watched_movie()
+            ref_movie = self.get_recently_watched_movie()
             # when getting a random movie, it's for a homescreen widget, and
             # and that means it should hide watched movies
             self.options["hide_watched"] = True
@@ -249,7 +249,7 @@ class Movies(object):
         else:
             return None
 
-    def get_random_recently_watched_movie(self):
+    def get_recently_watched_movie(self):
         '''gets a random recently watched movie from kodi_constants.'''
         movies = self.metadatautils.kodidb.movies(sort=kodi_constants.SORT_LASTPLAYED,
                                              filters=[kodi_constants.FILTER_WATCHED], limits=(0, 20))

--- a/resources/lib/movies.py
+++ b/resources/lib/movies.py
@@ -87,7 +87,8 @@ class Movies(object):
                     else:
                         j += 1
             # sort titles and cap at limit
-            similar_movies = sorted(similar_movies, key=itemgetter("similarscore"), reverse=True)[:self.options["limit"]]
+            similar_movies = sorted(similar_movies, key=itemgetter("similarscore"),
+                                                    reverse=True)[:self.options["limit"]]
             # scale score, and rewrite extraproperties for remaining movies
             for movie in similar_movies:
                 movie["recommendedscore"] = (movie["similarscore"]/len(recent_movies))**(1./2)
@@ -324,8 +325,19 @@ class Movies(object):
             # skip sort if set to false to save computer time
             return self.metadatautils.kodidb.movies(filters=filters, limits=(0, limit))
 
-    def get_similarity_score(self, ref_movie, other_movie,
-                                set_genres=None, set_directors=None, set_writers=None, set_cast=None):
+    def favourites(self):
+        '''get favourites'''
+        from favourites import Favourites
+        self.options["mediafilter"] = "movies"
+        return Favourites(self.addon, self.metadatautils, self.options).favourites()
+
+    def favourite(self):
+        '''synonym to favourites'''
+        return self.favourites()
+
+    @staticmethod
+    def get_similarity_score(ref_movie, other_movie, set_genres=None, set_directors=None,
+                                                        set_writers=None, set_cast=None):
         '''
             get a similarity score (0-1) between two movies
             optional parameters should be calculated beforehand if called inside loop
@@ -370,15 +382,5 @@ class Movies(object):
             .1*rating_score + .05*year_score + .025*mpaa_score
         # exponentially scale score for movies in same set
         if ref_movie["setid"] and ref_movie["setid"]==other_movie["setid"]:
-            similarscore = similarscore**(1./2)
+            similarscore **= (1./2)
         return similarscore
-
-    def favourites(self):
-        '''get favourites'''
-        from favourites import Favourites
-        self.options["mediafilter"] = "movies"
-        return Favourites(self.addon, self.metadatautils, self.options).favourites()
-
-    def favourite(self):
-        '''synonym to favourites'''
-        return self.favourites()

--- a/resources/lib/movies.py
+++ b/resources/lib/movies.py
@@ -105,7 +105,6 @@ class Movies(object):
         return self.metadatautils.kodidb.movies(sort=kodi_constants.SORT_TITLE, filters=filters,
                                            limits=(0, self.options["limit"]))
 
-
     def similar(self):
         ''' get similar movies for given imdbid or just from random watched title if no imdbid'''
         imdb_id = self.options.get("imdbid", "")
@@ -153,9 +152,9 @@ class Movies(object):
                             float(len(set_directors.intersection(item["director"])))/num_directors
                         rating_score = 0 if (not ref_rating) or (not item["rating"]) else \
                             1-abs(ref_rating-item["rating"])/10
-                        similarscore = .5*genre_score+.2*writer_score+.2*director_score+.1*rating_score
+                        similarscore = .5*genre_score + .2*writer_score + .2*director_score + .1*rating_score
                         if ref_setid and ref_setid==item["setid"]:
-                            similarscore = similarscore**(1/(1+set_exp))
+                            similarscore = similarscore**(1/3)
                         item["similarscore"] = similarscore
                         all_items.append(item)
                         all_titles.append(item["title"])
@@ -163,7 +162,6 @@ class Movies(object):
         self.options["hide_watched"] = hide_watched
         # return the list capped by limit and sorted by number of matching genres then rating
         return sorted(all_items, key=itemgetter("similarscore"), reverse=True)[:self.options["limit"]]
-
 
     def forgenre(self):
         ''' get top rated movies for given genre'''
@@ -180,7 +178,6 @@ class Movies(object):
                 # append original genre as listitem property for later reference by skinner
                 item["extraproperties"] = {"genretitle": genre, "originalpath": item["file"]}
                 all_items.append(item)
-
         # return the list sorted by rating
         return sorted(all_items, key=itemgetter("rating"), reverse=True)
 

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -8,6 +8,7 @@
         <setting id="default_limit" type="number" label="32053" default="25"/>
         <setting id="num_recent_similar" type="number" label="32072" default="8"/>
         <setting id="aggresive_refresh" type="bool" label="32071" default="false"/>
+        <setting id="exp_rec_movies" type="bool" label="32074" default="false"/>
     </category>
     <!-- episodes -->
     <category label="$LOCALIZE[20360]">
@@ -24,6 +25,6 @@
         <setting id="music_enable_artwork" type="bool" label="32024" default="false"/>
         <setting id="music_browse_album" type="bool" label="32026" default="false"/>
     </category>
-    
-    
+
+
 </settings>

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -6,8 +6,8 @@
         <setting id="hide_watched_recent" type="bool" label="32067" default="true"/>
         <setting id="hide_watched_similar" type="bool" label="32073" default="true"/>
         <setting id="default_limit" type="number" label="32053" default="25"/>
-        <setting id="aggresive_refresh" type="bool" label="32071" default="false"/>
         <setting id="num_recent_similar" type="number" label="32072" default="8"/>
+        <setting id="aggresive_refresh" type="bool" label="32071" default="false"/>
     </category>
     <!-- episodes -->
     <category label="$LOCALIZE[20360]">

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -6,6 +6,7 @@
         <setting id="hide_watched_recent" type="bool" label="32067" default="true"/>
         <setting id="default_limit" type="number" label="32053" default="25"/>
         <setting id="aggresive_refresh" type="bool" label="32071" default="false"/>
+        <setting id="num_recent_similar" type="number" label="32072" default="8"/>
     </category>
     <!-- episodes -->
     <category label="$LOCALIZE[20360]">

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -4,6 +4,7 @@
     <category label="32163">
         <setting id="hide_watched" type="bool" label="32035" default="false"/>
         <setting id="hide_watched_recent" type="bool" label="32067" default="true"/>
+        <setting id="hide_watched_similar" type="bool" label="32073" default="true"/>
         <setting id="default_limit" type="number" label="32053" default="25"/>
         <setting id="aggresive_refresh" type="bool" label="32071" default="false"/>
     </category>


### PR DESCRIPTION
New features and bug fixes for the Similar Movies/Tv Shows widgets.  I closed my previous pull requests and created this new branch on my fork so that I can continue development while waiting for a merge without creating conflicts.

**New features:**

- Similar Movies widget on homescreen will only choose from the last _x_ recently watched movies, rather than any watched movie. Configurable in settings (default=8).

- Added a setting for hiding watched items in Similar Movies widget (default=enabled).

- Completely changed the way similar movies are calculated.  Each movie with a matching genre now gets a fractional score (0-1), with contributions from...
    - up to 50% from matching genres
    - up to 15% from matching directors
    - up to 12.5% from matching writers
    - up to 5% from matching cast (only considers top 5 from each)
    - up to 10% from similar rating
    - up to 5% from similar year
    - 2.5% from same MPAA rating
    - exponentially scaled if movies are from the same set

- Altered the way similar tv shows are sorted.  Shows are sorted by number of matching genres, then difference in rating (rather than absolute rating).

- Adds an alternate implementation of Recommended Movies that can be turned on in settings.  It calculates similar titles for every recently watched movie, then combines the scores to get a single list.  Takes a few minutes to calculate, so it's off by default.

**Bug fixes:**

- Fixes issue #25 where similar movies showed result for wrong movie
- Fixed formatting for headings in README
  
**Feedback**

My personal library has a huge number of genres since I scrape them from DVD Netflix, so any feedback or suggestions on improving the similarity system for a typical TMDb-scraped library is welcome.